### PR TITLE
Fix dex config secret reading from env

### DIFF
--- a/config/dex.config.yaml
+++ b/config/dex.config.yaml
@@ -19,7 +19,7 @@ staticClients:
       - {{ .Env.OIDC_REDIRECT_URL }}
     name: Excalidraw
     public: true
-    secret: excalidraw-secret
+    secret: {{ .Env.OIDC_CLIENT_SECRET }}
 
 staticPasswords:
   - email: {{ .Env.ADMIN_EMAIL }}


### PR DESCRIPTION
Update Dex configuration to read the OIDC client secret from an environment variable to allow for custom secrets.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0641e48-985a-410b-a0ab-5999601a8c17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0641e48-985a-410b-a0ab-5999601a8c17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

