### PR TITLE
QEMU cross platform

### DIFF
--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -42,6 +42,9 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -51,6 +54,7 @@ jobs:
           context: .
           file: ./excalidraw-complete.Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,6 +44,9 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -53,6 +56,7 @@ jobs:
           context: .
           file: ./excalidraw-complete.Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.IMAGE_NAME }}:buildcache,mode=max


### PR DESCRIPTION
This pull request updates the Docker build configuration and Dockerfile to support multi-platform builds (specifically `linux/amd64` and `linux/arm64`). The changes ensure that builds can run on both x86 and ARM architectures by setting up QEMU for emulation, specifying build platforms in the workflow, and using platform-specific Dockerfile syntax and build arguments.

**Multi-platform build support:**

* Added the `Set up QEMU` step in both `.github/workflows/docker-build.yml` and `.github/workflows/docker-build-dev.yml` to enable emulation for ARM builds. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R47-R49) [[2]](diffhunk://#diff-964b38b3447ce731d0553d016cffc036dd1461da3141a6cc5440bc572f6dec87R45-R47)
* Updated the Docker build steps in both workflows to specify `platforms: linux/amd64,linux/arm64` for multi-architecture image builds. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R59) [[2]](diffhunk://#diff-964b38b3447ce731d0553d016cffc036dd1461da3141a6cc5440bc572f6dec87R57)

**Dockerfile improvements for cross-platform builds:**

* Modified all `FROM` instructions in `excalidraw-complete.Dockerfile` to use the `--platform` flag, enabling platform-specific builds.
* Added build arguments (`TARGETOS`, `TARGETARCH`, `TARGETPLATFORM`) and updated the Go build command to use these for correct cross-compilation. [[1]](diffhunk://#diff-e913caf5b75903e1bd34f92342bc82de3c6bfa079a9057037da1cc9624f20219L2-R14) [[2]](diffhunk://#diff-e913caf5b75903e1bd34f92342bc82de3c6bfa079a9057037da1cc9624f20219L21-R26)