### PR TITLE
feat(docker): make frontend AI endpoint/model configurable via build-args

### DIFF
--- a/excalidraw-complete.Dockerfile
+++ b/excalidraw-complete.Dockerfile
@@ -3,6 +3,11 @@ FROM --platform=$BUILDPLATFORM node:18 AS frontend-builder
 WORKDIR /app
 # 复制 excalidraw 子模块
 COPY excalidraw/ ./excalidraw/
+# AI endpoint/model configurability (build-args; unset = upstream defaults preserved)
+ARG VITE_APP_OPENAI_API_URL
+ARG VITE_APP_OPENAI_MODEL
+ENV VITE_APP_OPENAI_API_URL=${VITE_APP_OPENAI_API_URL}
+ENV VITE_APP_OPENAI_MODEL=${VITE_APP_OPENAI_MODEL}
 # 构建前端
 RUN cd excalidraw && npm install -g pnpm && pnpm install && cd excalidraw-app && DISABLE_VITE_CHECKER=true pnpm build:app:docker
 


### PR DESCRIPTION
## What

Expose the frontend's AI configuration as Docker build-args in
`excalidraw-complete.Dockerfile`'s `frontend-builder` stage:

- `VITE_APP_OPENAI_API_URL` — the AI endpoint (used by both AI paths)
- `VITE_APP_OPENAI_MODEL` — the model for the text path

## Why

The frontend reads these two `VITE_APP_*` variables at Vite build time. Today a
deployer who wants to point the AI features at a self-hosted / same-origin
endpoint has to edit source before building. Making them build-args lets the
image be configured at build time:

```
docker build -f excalidraw-complete.Dockerfile \
  --build-arg VITE_APP_OPENAI_API_URL=/api/v2 \
  --build-arg VITE_APP_OPENAI_MODEL=my-model .
```

## Behavior preserved

The `ARG`s have **no defaults** — when they aren't passed, the `ENV` resolves to
an empty string, which is falsy, so the app falls back to its existing per-path
defaults. Building without the build-args produces byte-identical frontend
behavior to before this change.
